### PR TITLE
feat: add demonstration branch for AutomationHub deploy demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# SixEyes — Environment Variables
+# Copy this file to .env and fill in your values before running docker compose up
+
+# Spring profile: use "dev" for local (H2 in-memory DB) or "prod" for PostgreSQL
+SPRING_PROFILES_ACTIVE=dev
+
+# PostgreSQL (only used when SPRING_PROFILES_ACTIVE=prod)
+DB_NAME=sixeyesdb
+DB_USERNAME=sixeyes
+DB_PASSWORD=changeme
+
+# JWT — generate a random base64 string, e.g.: openssl rand -base64 64
+JWT_SECRET=CHANGE_ME_base64_secret_at_least_32_chars
+
+# Admin credentials for the Java API
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=changeme
+
+# Download directory on the host (mounted into the Python container)
+DOWNLOAD_PATH=./downloads
+
+# ngrok auth token — get one free at https://ngrok.com
+# Required to expose the local PostgreSQL port to Cloud Run
+NGROK_AUTHTOKEN=CHANGE_ME_ngrok_token

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,42 @@
+# SixEyes — AutomationHub Demo
+
+This branch (`demonstration`) is configured for deployment via [AutomationHub](https://github.com/EduardoAlcaria/AutomationHub).
+
+## Deploy via AutomationHub
+
+### Option 1 — Full stack (monorepo, docker compose)
+
+AutomationHub detects `docker-compose.yml` at the repo root and runs:
+```
+docker compose up --build -d
+```
+
+This starts: PostgreSQL → ngrok TCP tunnel → Python agent → Java API → React frontend
+
+**Before deploying**, write a `.env` file on the target machine (see `.env.example`):
+```bash
+cp .env.example .env
+# edit .env with your real values
+```
+
+Ports exposed:
+| Service         | Port  |
+|-----------------|-------|
+| React frontend  | 4000  |
+| Java API        | 9090  |
+| Python agent    | 9999  |
+| ngrok inspector | 4040  |
+
+### Option 2 — Frontend only (Node.js)
+
+To deploy just the dashboard as a Node.js app, point AutomationHub at the
+`js/torrent-dashboard` subdirectory — or use a branch that has a root `package.json`
+(see `frontend-only` branch if it exists).
+
+## Two-repo pattern
+
+You can also model this as two separate AutomationHub deployments:
+- **sixeyes-frontend** — repo: this repo, branch: `demonstration`
+- **sixeyes-api** — repo: this repo, branch: `demonstration`
+
+Each clones the full repo and runs its respective Dockerfile independently.


### PR DESCRIPTION
Adds .env.example with all required environment variables and DEMO.md explaining how to deploy via AutomationHub (monorepo and 2-repo patterns).